### PR TITLE
[feat] #121 추천글 조회 응답에 작성자 관리자 여부(isAdmin) 필드 추가

### DIFF
--- a/src/main/java/org/dplay/server/controller/question/dto/PastRecommendationFeedItemResponse.java
+++ b/src/main/java/org/dplay/server/controller/question/dto/PastRecommendationFeedItemResponse.java
@@ -30,7 +30,8 @@ public record PastRecommendationFeedItemResponse(
         PastRecommendationFeedUser feedUser = new PastRecommendationFeedUser(
                 author.getUserId(),
                 author.getNickname(),
-                author.getProfileImg()
+                author.getProfileImg(),
+                author.isEditor()
         );
 
         PastRecommendationFeedLike feedLike = new PastRecommendationFeedLike(

--- a/src/main/java/org/dplay/server/controller/question/dto/PastRecommendationFeedUser.java
+++ b/src/main/java/org/dplay/server/controller/question/dto/PastRecommendationFeedUser.java
@@ -3,6 +3,7 @@ package org.dplay.server.controller.question.dto;
 public record PastRecommendationFeedUser(
         Long userId,
         String nickname,
-        String profileImg
+        String profileImg,
+        boolean isAdmin
 ) {
 }

--- a/src/main/java/org/dplay/server/controller/question/dto/TodayRecommendationFeedItemResponse.java
+++ b/src/main/java/org/dplay/server/controller/question/dto/TodayRecommendationFeedItemResponse.java
@@ -31,7 +31,8 @@ public record TodayRecommendationFeedItemResponse(
         TodayRecommendationFeedUser feedUser = new TodayRecommendationFeedUser(
                 author.getUserId(),
                 author.getNickname(),
-                author.getProfileImg()
+                author.getProfileImg(),
+                author.isEditor()
         );
 
         TodayRecommendationFeedLike feedLike = new TodayRecommendationFeedLike(

--- a/src/main/java/org/dplay/server/controller/question/dto/TodayRecommendationFeedUser.java
+++ b/src/main/java/org/dplay/server/controller/question/dto/TodayRecommendationFeedUser.java
@@ -3,6 +3,7 @@ package org.dplay.server.controller.question.dto;
 public record TodayRecommendationFeedUser(
         Long userId,
         String nickname,
-        String profileImg
+        String profileImg,
+        boolean isAdmin
 ) {
 }

--- a/src/main/java/org/dplay/server/controller/user/dto/UserResponse.java
+++ b/src/main/java/org/dplay/server/controller/user/dto/UserResponse.java
@@ -5,10 +5,11 @@ import org.dplay.server.domain.user.dto.UserDetailResultDto;
 public record UserResponse(
         Long userId,
         String nickname,
-        String profileImg
+        String profileImg,
+        boolean isAdmin
 ) {
 
     public static UserResponse from(UserDetailResultDto resultDto) {
-        return new UserResponse(resultDto.userId(), resultDto.nickname(), resultDto.profileImg());
+        return new UserResponse(resultDto.userId(), resultDto.nickname(), resultDto.profileImg(), resultDto.isAdmin());
     }
 }

--- a/src/main/java/org/dplay/server/domain/user/dto/UserDetailResultDto.java
+++ b/src/main/java/org/dplay/server/domain/user/dto/UserDetailResultDto.java
@@ -5,9 +5,10 @@ import org.dplay.server.domain.user.entity.User;
 public record UserDetailResultDto(
         Long userId,
         String nickname,
-        String profileImg
+        String profileImg,
+        boolean isAdmin
 ) {
     public static UserDetailResultDto from(User user) {
-        return new UserDetailResultDto(user.getUserId(), user.getNickname(), user.getProfileImg());
+        return new UserDetailResultDto(user.getUserId(), user.getNickname(), user.getProfileImg(), user.isEditor());
     }
 }


### PR DESCRIPTION
 ## 📌 PR 제목                                                                                                                                                            
  [FEAT] #121 추천글 조회 응답에 작성자 관리자 여부(isAdmin) 필드 추가                                                                                                     
                                                                                                                                                                           
  ## 변경 사항                                                                                                                                                             
  추천글 조회 API 응답의 `user` 객체에 `isAdmin` 필드를 추가하여 작성자의 관리자 여부를 반환합니다.                                                                        
  - 오늘의 추천글 리스트 조회 (`GET /v1/posts/today`)                                                                                                                      
  - 지난 추천글 리스트 조회 (`GET /v1/posts/{questionId}`)                                                                                                                 
  - 추천글 상세 조회 (`GET /v1/posts/detail/{postId}`)                                                                                                                     
                                                                                                                                                                           
  ## 변경 유형                                                                                                                                                             
  - [x] 새로운 기능 (New feature)                                                                                                                                          
                                                                                                                                                                           
  ## 관련 이슈                                                                                                                                                             
  - Closes #121                                                                                                                                                            
                                                                                                                                                                           
  ## 상세 설명                                                                                                                                                             
  - `UserDetailResultDto`에 `isAdmin` 필드 추가, `User.isEditor` 값을 매핑                                                                                                 
  - `UserResponse`에 `isAdmin` 필드 추가 (상세 조회 응답)                                                                                                                  
  - `TodayRecommendationFeedUser`에 `isAdmin` 필드 추가 (오늘의 추천 피드)                                                                                                 
  - `PastRecommendationFeedUser`에 `isAdmin` 필드 추가 (지난 추천 피드)                                                                                                    
                                                                                                                                                                           
  ## 체크리스트                                                                                                                                                            
  - [x] 코드 스타일 가이드를 준수했나요?                                                                                                                                   
  - [x] 자체 검토(self-review)를 진행했나요?                                                                                                                               
  - [x] 새로운 경고나 오류가 없는지 확인했나요?                                                                                                                            
  - [x] 관련된 다른 코드에 영향을 미치지 않는지 확인했나요?                                                                                                                
                                                                                                                                                                           
  ## 테스트 방법                                                                                                                                                           
  1. 오늘의 추천글 조회 API 호출 후 응답의 `items[].user.isAdmin` 필드 확인                                                                                                
  2. 지난 추천글 조회 API 호출 후 응답의 `items[].user.isAdmin` 필드 확인                                                                                                  
  3. 추천글 상세 조회 API 호출 후 응답의 `user.isAdmin` 필드 확인          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 사용자 정보 응답 객체에 관리자 상태 필드를 추가했습니다.
  * 추천 피드 및 사용자 응답 데이터 구조를 업데이트하여 추가 상태 정보를 포함하도록 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->